### PR TITLE
fix(release): Update core package version in publish scripts

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -68,8 +68,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      
-
       - name: Publish @hahnd/geminid nightly
         run: npm publish --workspace=@hahnd/geminid --tag=nightly --access public
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      
-
       - name: Publish @hahnd/geminid
         run: npm publish --workspace=@hahnd/geminid --tag=${{ steps.version.outputs.NPM_TAG }} --access public
         env:

--- a/integration-tests/file-system.test.js
+++ b/integration-tests/file-system.test.js
@@ -18,9 +18,7 @@ test('reads a file', (t) => {
   rig = new TestRig();
   rig.setup(t.name);
   rig.createFile('test.txt', 'hello world');
-
   const output = rig.run(`read the file name test.txt`);
-
   assert.ok(output.toLowerCase().includes('hello'));
 });
 
@@ -28,9 +26,7 @@ test('writes a file', (t) => {
   rig = new TestRig();
   rig.setup(t.name);
   rig.createFile('test.txt', '');
-
   rig.run(`edit test.txt to have a hello world message`);
-
   const fileContent = rig.readFile('test.txt');
   assert.ok(fileContent.toLowerCase().includes('hello'));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11990,7 +11990,7 @@
     },
     "packages/core": {
       "name": "@hahnd/gemini-cli-core",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@google/genai": "1.9.0",
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hahnd/gemini-cli-core",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Gemini CLI Core",
   "repository": {
     "type": "git",

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -490,7 +490,15 @@ export class GeminiClient {
         throw error;
       }
       try {
-        return JSON.parse(text);
+        // Remove markdown code block wrappers if present
+        let cleanedText = text.trim();
+        if (cleanedText.startsWith('```json')) {
+          cleanedText = cleanedText.substring('```json'.length);
+        }
+        if (cleanedText.endsWith('```')) {
+          cleanedText = cleanedText.substring(0, cleanedText.length - '```'.length);
+        }
+        return JSON.parse(cleanedText);
       } catch (parseError) {
         await reportError(
           parseError,

--- a/scripts/publish_develop.js
+++ b/scripts/publish_develop.js
@@ -50,6 +50,21 @@ try {
     console.log(`${cliPackageJsonPath} already at version ${newVersion}.`);
   }
 
+  // Check and update packages/core/package.json
+  const corePackageJsonPath = join(process.cwd(), 'packages/core/package.json');
+  const corePackageJsonContent = readFileSync(corePackageJsonPath, 'utf8');
+  const corePackageJson = JSON.parse(corePackageJsonContent);
+  if (corePackageJson.version !== newVersion) {
+    corePackageJson.version = newVersion;
+    writeFileSync(
+      corePackageJsonPath,
+      JSON.stringify(corePackageJson, null, 2) + '\n',
+    );
+    console.log(`Updated ${corePackageJsonPath} to version ${newVersion}`);
+  } else {
+    console.log(`${corePackageJsonPath} already at version ${newVersion}.`);
+  }
+
   if (!newVersion) {
     newVersion = rootPackageJson.version;
     console.log(

--- a/scripts/publish_release.js
+++ b/scripts/publish_release.js
@@ -55,6 +55,21 @@ try {
     console.log(`${cliPackageJsonPath} already at version ${newVersion}.`);
   }
 
+  // Check and update packages/core/package.json
+  const corePackageJsonPath = join(process.cwd(), 'packages/core/package.json');
+  const corePackageJsonContent = readFileSync(corePackageJsonPath, 'utf8');
+  const corePackageJson = JSON.parse(corePackageJsonContent);
+  if (corePackageJson.version !== newVersion) {
+    corePackageJson.version = newVersion;
+    writeFileSync(
+      corePackageJsonPath,
+      JSON.stringify(corePackageJson, null, 2) + '\n',
+    );
+    console.log(`Updated ${corePackageJsonPath} to version ${newVersion}`);
+  } else {
+    console.log(`${corePackageJsonPath} already at version ${newVersion}.`);
+  }
+
   // Fetch
   try {
     execSync('git fetch origin hermannhahn/release');


### PR DESCRIPTION
This commit modifies `scripts/publish_develop.js` and `scripts/publish_release.js` to ensure that the `packages/core/package.json` version is also updated during the publishing process. This resolves the issue where the `gemini-cli-core` package was not being correctly versioned, leading to "403 Forbidden" errors during nightly releases.

