### PR TITLE
fix(release): Correct nightly release tag and title

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -48,8 +48,7 @@ jobs:
         id: get_nightly_version
         run: |
           # Use the existing script to get the nightly tag name
-          VERSION_JSON=$(node scripts/get-release-version.js)
-          NIGHTLY_TAG=$(echo $VERSION_JSON | jq -r .nightlyTag)
+          NIGHTLY_TAG=$(node -e 'import { getNightlyTagName } from "./scripts/get-release-version.js"; console.log(getNightlyTagName());')
           echo "NIGHTLY_TAG=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
           echo "NIGHTLY_VERSION=${NIGHTLY_TAG#v}" >> $GITHUB_OUTPUT # Remove 'v' prefix for npm version
 


### PR DESCRIPTION
This commit modifies `.github/workflows/nightly-release.yml` to correctly generate the nightly release tag and title. Previously, it was attempting to extract `nightlyTag` from a JSON object that did not contain it, resulting in "null" values. The workflow now explicitly calls the `getNightlyTagName()` function from `scripts/get-release-version.js` to ensure proper versioning.

